### PR TITLE
Added batch file to install and run app 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 This readme file was created by Confused_scientists for the AI+Environment Hackathon 2024
 
+# HOW TO RUN THE CODE
+
+Windows:
+
+1. Double-click start_app.bat
+
+NOTE: If you solely use Anaconda for python, open Anaconda Prompt and run the following command:
+
+```bash
+start_app.bat
+```
+
+Mac/Linux:
+
+1. Open terminal
+2. Navigate to the folder
+3. Run: chmod +x start_app.sh
+4. Run: ./start_app.sh
+
+The browser should open automatically. If not, copy the URL from the terminal and paste it into your browser. (e.g. http://localhost:8501)
+If you want to run the code in a different environment, you can use the following command to run the app:
+
+```bash
+streamlit run app.py --server.port your_port_no --server.address
+```
+
 # HOW TO RUN STREAMLIT
 
 1. Install streamlit by running `pip install streamlit`

--- a/app.py
+++ b/app.py
@@ -1,6 +1,9 @@
 import streamlit as st
 import numpy as np
 import pandas as pd
+import os
+import psutil
+import signal
 import random
 
 from pathlib import Path
@@ -143,6 +146,19 @@ def plot_file(file_path,sunrise_sunset_data):
     
     return fig1, fig2, fig3, fig4
 
+# Add a button to close the app
+col1, col2 = st.columns([4, 1])
+
+with col1:
+    st.info("Click the Close App ❌ button to safely close the app and then close this tab. It will shut down the server running in the background. Closing the tab alone will not shut down the server.  ")
+
+with col2:
+    close = st.button("❌ Close App", key="close_app_button")
+
+# Handle button press
+if close:
+    st.success("Shutting down the app. Please close this tab.")
+    os.kill(os.getpid(), signal.SIGTERM)
 
 
 # Select the folder containing the audio files or select the audio files


### PR DESCRIPTION
Easier installation and app running for non python users. Batch file and bash script added, which can be run using double click or just typing start_app.bat in console. 
checks for virtual environment, creates one if doesn't exist and runs app. 

added way to shut down server from streamlit app